### PR TITLE
Disable S3 ACLs

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -17,7 +17,7 @@ resource "aws_s3_bucket_ownership_controls" "bucket" {
   bucket = aws_s3_bucket.bucket.id
 
   rule {
-    object_ownership = "BucketOwnerPreferred"
+    object_ownership = "BucketOwnerEnforced"
   }
 }
 


### PR DESCRIPTION
- Disable S3 ACLs to enable Cascade publishing permissions