### PR TITLE
Enable cache invalidation via publishing a file to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ localstack/testing_output
 **/sm-key*
 .DS_Store
 *.zip
+**/.aws-sam

--- a/LambdaEdgeFunctions/cf_cache_invalidation/docker-compose.yml
+++ b/LambdaEdgeFunctions/cf_cache_invalidation/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.9"
+services:
+  build:
+    image: public.ecr.aws/lambda/nodejs:${LAMBDA_RUNTIME}
+    volumes:
+      - ./:/app
+    entrypoint: bash -c 'cd /app && npm install'

--- a/LambdaEdgeFunctions/cf_cache_invalidation/event.json
+++ b/LambdaEdgeFunctions/cf_cache_invalidation/event.json
@@ -1,0 +1,38 @@
+{
+  "Records": [
+    {
+      "eventVersion": "2.1",
+      "eventSource": "aws:s3",
+      "awsRegion": "us-east-1",
+      "eventTime": "1970-01-01T00:00:00.000Z",
+      "eventName": "ObjectCreated:Put",
+      "userIdentity": {
+        "principalId": "EXAMPLE"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "127.0.0.1"
+      },
+      "responseElements": {
+        "x-amz-request-id": "EXAMPLE123456789",
+        "x-amz-id-2": "EXAMPLE123/5678abcdefghijklambdaisawesome/mnopqrstuvwxyzABCDEFGH"
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "testConfigRule",
+        "bucket": {
+          "name": "site-blake-test-engr-tamu-edu-dev",
+          "ownerIdentity": {
+            "principalId": "EXAMPLE"
+          },
+          "arn": "arn:aws:s3:::site-blake-test-engr-tamu-edu-dev"
+        },
+        "object": {
+          "key": "invalidate_cache.txt",
+          "size": 1024,
+          "eTag": "d41d8cd98f00b204e9800998ecf8427e",
+          "sequencer": "0A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q7R8S9T0U1V2W3X4Y5Z"
+        }
+      }
+    }
+  ]
+}

--- a/LambdaEdgeFunctions/cf_cache_invalidation/index.js
+++ b/LambdaEdgeFunctions/cf_cache_invalidation/index.js
@@ -1,0 +1,87 @@
+const {
+    GetObjectCommand,
+	S3Client
+} = require("@aws-sdk/client-s3");
+
+const { 
+    CloudFrontClient, 
+    CreateInvalidationCommand,
+    ListDistributionsCommand
+} = require("@aws-sdk/client-cloudfront");
+
+module.exports.handler = async (event, context, callback) => {
+    const event_source = event.Records[0].eventSource;
+
+    if (event_source !== 'aws:s3') {
+        console.log(`Invalid event source: ${event_source}; expected 'aws:s3'`);
+        callback(null, event);
+    }
+    const bucket_name = event.Records[0].s3.bucket.name;
+    const object_key = event.Records[0].s3.object.key;
+
+    if (object_key !== 'invalidate_cache.txt') {
+        console.log(`Ignoring object key: ${object_key}; expected 'invalidate_cache.txt'`);
+        callback(null, event);
+    }
+
+    // Determine which CloudFront distribution to invalidate based on the bucket ARN
+    cf_client = new CloudFrontClient({});
+    // Get all of the distributions
+    const cf_list_request = new ListDistributionsCommand({});
+    const cf_distributions = await cf_client.send(cf_list_request);
+    // console.log(`Found distributions: ${JSON.stringify(cf_distributions, null, 2)}`);
+
+
+    // Go through each distribution and find the one with the matching bucket name
+    let distribution_id = null;
+    for (let distribution of cf_distributions.DistributionList.Items) {
+        if (distribution.Origins.Items[0].Id == bucket_name) {
+            distribution_id = distribution.Id;
+            break;
+        }
+    }
+
+    if (distribution_id === null) {
+        console.error(`No distribution found for bucket ${bucket_name}`);
+        callback(null, event);
+    }
+
+    console.log(`Found distribution ${distribution_id} for bucket ${bucket_name}`);
+
+    const s3_client = new S3Client({});
+
+    // Fetch the object contents
+    const s3_request = new GetObjectCommand({
+        Bucket: bucket_name,
+        Key: object_key
+    });
+    let object_data = null;
+    try {
+        const s3_response = await s3_client.send(s3_request);
+        object_data = (await s3_response.Body.transformToString()).trim();
+        console.log(`Object ${object_key} was successfully retrieved from bucket ${bucket_name}: ${object_data}`);
+    } catch (err) {
+        console.error(`Error retrieving object ${object_key} from bucket ${bucket_name}: ${err}`);
+        callback(null, event)
+    }
+
+    // Parse the object contents
+    const invalidation_paths = object_data.split('\n');
+    // Delete the top line of the object data, which is the timestamp
+    invalidation_paths.shift();
+
+    console.log(`Invalidating the following paths: ${invalidation_paths}`);
+    cf_invalidation_request = new CreateInvalidationCommand({
+        DistributionId: distribution_id,
+        InvalidationBatch: {
+            CallerReference: Date.now().toString(),
+            Paths: {
+                Quantity: invalidation_paths.length,
+                Items: invalidation_paths
+            }
+        }
+    }); 
+    cf_invalidation_response = await cf_client.send(cf_invalidation_request);
+    
+    callback(null, event);
+};

--- a/LambdaEdgeFunctions/cf_cache_invalidation/invalidate_cache.txt
+++ b/LambdaEdgeFunctions/cf_cache_invalidation/invalidate_cache.txt
@@ -1,0 +1,3 @@
+Timestamp: 1707246974
+/test
+/*

--- a/LambdaEdgeFunctions/cf_cache_invalidation/package-lock.json
+++ b/LambdaEdgeFunctions/cf_cache_invalidation/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "cf-cache-invalidation",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cf-cache-invalidation",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {}
+    }
+  }
+}

--- a/LambdaEdgeFunctions/cf_cache_invalidation/package.json
+++ b/LambdaEdgeFunctions/cf_cache_invalidation/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cf-cache-invalidation",
+  "version": "1.0.0",
+  "description": "Event-driven lambda to invalidate a CloudFront cache",
+  "repository": "",
+  "author": "Blake Dworaczyk<blaked@tamu.edu>",
+  "license": "MIT",
+  "dependencies": {
+  },
+  "devDependencies": {
+  }
+}

--- a/LambdaEdgeFunctions/cf_cache_invalidation/template.yaml
+++ b/LambdaEdgeFunctions/cf_cache_invalidation/template.yaml
@@ -1,0 +1,15 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: SAM configuration for cloudfront cache invalidation function (SAM is used for local testing only)
+Resources:
+  CloudFrontCacheInvalidationFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Role: !GetAtt LambdaEdgeFunctionRole.Arn
+      Runtime: nodejs20.x
+      Handler: index.handler
+      Timeout: 20 
+      AutoPublishAlias: LIVE

--- a/LambdaEdgeFunctions/cf_cache_invalidation/test_locally.sh
+++ b/LambdaEdgeFunctions/cf_cache_invalidation/test_locally.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sam build \
+  --use-container && \
+sam local invoke CloudFrontCacheInvalidationFunction \
+  --profile vpasc_vpmc_static_sites_multi_dev \
+  --event ./event.json

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ The `site_settings` line take a dictionary of variable overrides and includes th
 |route53_tld|cloud.tamu.edu|The top level domain in route53 where subdomains are added|
 |rules_cache_timeout|3602|The number of seconds to cache rewrite rules|
 
+## Cache Invalidation
+The cache can be invalidated for a CloudFront distribution by publishing a file
+named `invalidate_cache.txt` to the root of the distribution's S3 bucket. The
+first line should contain a timestamp, and each additional line should contain 
+invalidation paths. For example:
+
+```text
+1707345054
+/test
+/*
+```
+
 ## IAM User Bucket Credentials
 
 Access to IAM user credentials for S3 bucket access is provided through [TAMU's instance of


### PR DESCRIPTION
- Allow a CF distribution's cache to be invalidated by publishing a file called "invalidate_cache.txt" to the root of the distributon's S3 bucket.