### PR TITLE
Rename S3 buckets to ensure no conflict during site migrations

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "bucket" {
-  bucket        = "site-${local.site_name_dashes}-${var.deployment}"
+  bucket        = "${data.aws_caller_identity.current.account_id}-site-${local.site_name_dashes}-${var.deployment}"
   force_destroy = var.allow_bucket_force_destroy
 }
 
@@ -32,7 +32,7 @@ resource "aws_s3_bucket_public_access_block" "bucket" {
 }
 
 resource "aws_s3_bucket" "bucket_logging" {
-  bucket        = "site-${local.site_name_dashes}-${var.deployment}-logs"
+  bucket        = "${data.aws_caller_identity.current.account_id}-site-${local.site_name_dashes}-${var.deployment}-logs"
   force_destroy = var.allow_bucket_force_destroy
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "additional_cloudfront_aliases" {
 variable "allow_bucket_force_destroy" {
   type        = bool
   description = "Allow buckets to be destroyed when doing a terraform destroy"
-  default     = false
+  default     = true
 }
 
 variable "aws_account_name" {


### PR DESCRIPTION
Rename S3 bucket to include the account number prefix to ensure uniqueness across accounts. This ensures that sites can be migrated without the new system attempting to create duplicate S3 buckets, which must be globally unique.