### PR TITLE
Put S3 bucket names back because force_destroy must be applied first

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "bucket" {
-  bucket        = "${data.aws_caller_identity.current.account_id}-site-${local.site_name_dashes}-${var.deployment}"
+  #bucket        = "${data.aws_caller_identity.current.account_id}-site-${local.site_name_dashes}-${var.deployment}"
+  bucket        = "site-${local.site_name_dashes}-${var.deployment}"
   force_destroy = var.allow_bucket_force_destroy
 }
 
@@ -32,7 +33,8 @@ resource "aws_s3_bucket_public_access_block" "bucket" {
 }
 
 resource "aws_s3_bucket" "bucket_logging" {
-  bucket        = "${data.aws_caller_identity.current.account_id}-site-${local.site_name_dashes}-${var.deployment}-logs"
+  #bucket        = "${data.aws_caller_identity.current.account_id}-site-${local.site_name_dashes}-${var.deployment}-logs"
+  bucket        = "site-${local.site_name_dashes}-${var.deployment}-logs"
   force_destroy = var.allow_bucket_force_destroy
 }
 


### PR DESCRIPTION
- Put S3 bucket names back because the terraform force_destroy attribute must be applied to the S3 buckets first