### PR TITLE
Attempt to mitigate bucket ACL ownership race condition

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -683,7 +683,9 @@ resource "aws_cloudfront_distribution" "site" {
   }
 
   depends_on = [
-    aws_acm_certificate_validation.cert
+    aws_acm_certificate_validation.cert,
+    aws_s3_bucket_ownership_controls.bucket,
+    aws_s3_bucket_ownership_controls.bucket_logging
   ]
 }
 


### PR DESCRIPTION
Attempt to mitigate bucket ACL ownership race condition when replacing origin buckets and updating the CloudFront distribution