### PR TITLE
Start using AWS WAF

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -252,3 +252,9 @@ variable "sso_pages" {
   description = "A list of regular expressions that will be used to determine which pages require SSO authentication"
   default     = []
 }
+
+variable "web_acl_name" {
+  type        = string
+  description = "The name of the web ACL to associate with the CloudFront distribution"
+  default     = "default-cf-web-acl"
+}


### PR DESCRIPTION
Add an AWS WAF to all CloudFront distributions. The WAF is created as part of the account bootstrapping procedure, and associated with a distribution when the cf distro is made or updated via this module.