### PR TITLE
Allow infoblox dns record bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The `site_settings` line take a dictionary of variable overrides and includes th
 |rewrite_rules_location||The publicly accessible URL of the rewrite rules file|
 |route53_tld|cloud.tamu.edu|The top level domain in route53 where subdomains are added|
 |rules_cache_timeout|3602|The number of seconds to cache rewrite rules|
+|use_infoblox|true|Whether or not to insert infoblox domain validation records if necessary|
 
 ## Cache Invalidation
 The cache can be invalidated for a CloudFront distribution by publishing a file

--- a/certs.tf
+++ b/certs.tf
@@ -12,6 +12,8 @@ locals {
     try(var.site_settings.additional_certs, var.additional_certs)
   ))
 
+  use_infoblox = try(tobool(var.site_settings.use_infoblox), true)
+
 }
 
 resource "aws_acm_certificate" "cert" {
@@ -50,7 +52,7 @@ resource "infoblox_cname_record" "aws_cert_cname_record_tamu"{
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
-    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu")
+    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && local.use_infoblox
   }
 
   canonical	= trim(each.value.record, ".")
@@ -67,7 +69,7 @@ resource "infoblox_cname_record" "aws_cert_cname_record_internet"{
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
-    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu")
+    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && local.use_infoblox
   }
 
   canonical	= trim(each.value.record, ".")


### PR DESCRIPTION
- Allow bypassing of infoblox domain validation record creation with a new setting `use_infoblox` that defaults to `true`