### PR TITLE
Allow global_accelerator YAML property to be a list or a string

### DIFF
--- a/certs.tf
+++ b/certs.tf
@@ -8,7 +8,7 @@ locals {
     var.site_settings.top_level_domain == "" || var.deployment != "prod" ? [] : [var.site_settings.top_level_domain],
     var.site_settings.additional_domains == null ? tolist([]) : (var.deployment != "prod" ? tolist([]) : tolist(var.site_settings.additional_domains)),
     # This is for the optional global accelerator
-    try(var.site_settings.global_accelerator, "") == "" ? [] : [var.site_settings.global_accelerator],
+    try(var.site_settings.global_accelerator, "") == "" ? [] : flatten([var.site_settings.global_accelerator]),
     try(var.site_settings.additional_certs, var.additional_certs)
   ))
 

--- a/variables.tf
+++ b/variables.tf
@@ -88,20 +88,8 @@ variable "error_response_404_path" {
 #  default     = false
 #}
 
-variable "global_accelerator" {
-  description = "The FQDN for the global accelerator (i.e., tamu.edu) certificate. Leave blank to not generate a cert"
-  type        = string
-  default     = ""
-}
-
-#variable "global_accelerator_source" {
-#  description = "The source address for the global accelerator (i.e., tamu.edu). Leave blank to not use a GA"
-#  type        = string
-#  default     = ""
-#}
-#
-#variable "global_accelerator_target" {
-#  description = "The target address for the global accelerator (i.e., www.tamu.edu). Leave blank to not use a GA"
+#variable "global_accelerator" {
+#  description = "The FQDN for the global accelerator (i.e., tamu.edu) certificate. Leave blank to not generate a cert"
 #  type        = string
 #  default     = ""
 #}


### PR DESCRIPTION
Some sites need multiple A records for their additional aliases. Allow the `global_accelerator` site setting YAML attribute to be a string, or, now, a list.