### PR TITLE
Ensure that using SSO still uses the host header for cache keys

### DIFF
--- a/LambdaEdgeFunctions/host_header/package-lock.json
+++ b/LambdaEdgeFunctions/host_header/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "cascade-www-edge-host-headers",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cascade-www-edge-host-headers",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {}
+    }
+  }
+}

--- a/LambdaEdgeFunctions/rewrite/api/rules.js
+++ b/LambdaEdgeFunctions/rewrite/api/rules.js
@@ -10,6 +10,7 @@ const hostSyntax =  /H=([^,]+)/;
 const flagSyntax = /\[([^\]]+)]$/;
 const partsSyntax = /\s+|\t+/g;
 const DEFAULT_CACHE_TIMEOUT = 600 * 1000; // (600 seconds in milliseconds)
+//const DEFAULT_CACHE_TIMEOUT = 10 * 1000; // (10 seconds in milliseconds)
 
 const default_rules = [
   "^//.* /index.html [R,L]",

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -91,7 +91,7 @@ resource "aws_cloudfront_distribution" "site" {
         forward = "none"
       }
 
-      headers = local.enable_hostname_rewrites ? ["X-Forwarded-Host"] : null
+      headers = local.enable_hostname_header_caching ? ["X-Forwarded-Host"] : null
     }
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
@@ -143,7 +143,7 @@ resource "aws_cloudfront_distribution" "site" {
 
     forwarded_values {
       query_string = false
-      headers      = local.enable_hostname_rewrites ? ["Origin", "X-Forwarded-Host"] : ["Origin"]
+      headers      = local.enable_hostname_header_caching ? ["Origin", "X-Forwarded-Host"] : ["Origin"]
 
       cookies {
         forward = "none"
@@ -218,7 +218,7 @@ resource "aws_cloudfront_distribution" "site" {
         forward = "none"
       }
 
-      headers = local.enable_hostname_rewrites ? ["X-Forwarded-Host"] : null
+      headers = local.enable_hostname_header_caching ? ["X-Forwarded-Host"] : null
     }
 
     lambda_function_association {
@@ -250,7 +250,7 @@ resource "aws_cloudfront_distribution" "site" {
         forward = "none"
       }
 
-      headers = local.enable_hostname_rewrites ? ["X-Forwarded-Host"] : null
+      headers = local.enable_hostname_header_caching ? ["X-Forwarded-Host"] : null
     }
 
     lambda_function_association {
@@ -307,7 +307,7 @@ resource "aws_cloudfront_distribution" "site" {
         forward = "none"
       }
 
-      headers = local.enable_hostname_rewrites ? ["X-Forwarded-Host"] : null
+      headers = local.enable_hostname_header_caching ? ["X-Forwarded-Host"] : null
     }
 
     lambda_function_association {
@@ -364,7 +364,7 @@ resource "aws_cloudfront_distribution" "site" {
         forward = "none"
       }
 
-      headers = local.enable_hostname_rewrites ? ["X-Forwarded-Host"] : null
+      headers = local.enable_hostname_header_caching ? ["X-Forwarded-Host"] : null
     }
 
     lambda_function_association {
@@ -421,7 +421,7 @@ resource "aws_cloudfront_distribution" "site" {
         forward = "none"
       }
 
-      headers = local.enable_hostname_rewrites ? ["X-Forwarded-Host"] : null
+      headers = local.enable_hostname_header_caching ? ["X-Forwarded-Host"] : null
     }
 
     lambda_function_association {
@@ -478,7 +478,7 @@ resource "aws_cloudfront_distribution" "site" {
         forward = "none"
       }
 
-      headers = local.enable_hostname_rewrites ? ["X-Forwarded-Host"] : null
+      headers = local.enable_hostname_header_caching ? ["X-Forwarded-Host"] : null
     }
 
     lambda_function_association {
@@ -535,7 +535,7 @@ resource "aws_cloudfront_distribution" "site" {
         forward = "none"
       }
 
-      headers = local.enable_hostname_rewrites ? ["X-Forwarded-Host"] : null
+      headers = local.enable_hostname_header_caching ? ["X-Forwarded-Host"] : null
     }
 
     lambda_function_association {
@@ -592,7 +592,7 @@ resource "aws_cloudfront_distribution" "site" {
         forward = "none"
       }
 
-      headers = local.enable_hostname_rewrites ? ["X-Forwarded-Host"] : null
+      headers = local.enable_hostname_header_caching ? ["X-Forwarded-Host"] : null
     }
 
     lambda_function_association {
@@ -649,7 +649,7 @@ resource "aws_cloudfront_distribution" "site" {
         forward = "none"
       }
 
-      headers = local.enable_hostname_rewrites ? ["X-Forwarded-Host"] : null
+      headers = local.enable_hostname_header_caching ? ["X-Forwarded-Host"] : null
     }
 
     lambda_function_association {

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,5 +1,7 @@
 locals {
-  enable_hostname_rewrites = try(var.site_settings.enable_hostname_rewrites == "true", var.enable_hostname_rewrites)
+  enable_hostname_rewrites = try(var.site_settings.enable_hostname_rewrites, var.enable_hostname_rewrites)
+  enable_sso_auth = try(var.site_settings.sso_required, var.sso_required)
+  enable_hostname_header_caching = local.enable_hostname_rewrites || local.enable_sso_auth
 }
 
 resource "aws_iam_role" "iam_for_lambda" {


### PR DESCRIPTION
When using the SSO feature, since it now has passes the `host` header as the `x-forwarded-host` header, ensure that Cloudfront caching takes the `x-forwarded-host` header into account to enable the cache to distinguish between the site that the user typed into their browser (for the purpose of host-based redirects).