### PR TITLE
Adds support for using domains outside of infoblox

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ module "aws_static_site" {
     route53_name          = "blake-website-test"
     additional_domains    = []
     additional_certs      = []
+    external_domains      = []
     sso_required          = true
     sso_pages             = [
       "^/testing.*"
@@ -39,6 +40,7 @@ The `site_settings` line take a dictionary of variable overrides and includes th
 |additional_certs|[]|Additional SANs to add to the generated cert|
 |additional_cloudfront_aliases|[]|Additional aliases that will be added to CloudFront without being added as cert SANs|
 |additional_domains|[]|Additional domains that will be added as aliases and cert SANs|
+|external_domains|[]|External domains that skip automatic validation. Manual DNS records must be created for these domains.|
 |css_ttl|2592000|The number of seconds to cache CSS content|
 |def_html_ttl|1801|The number of seconds to cache HTML content|
 |default_ttl|60|Default number of seconds to cache content|

--- a/certs.tf
+++ b/certs.tf
@@ -6,7 +6,7 @@ locals {
     [local.domain],
     # This is for the top-level domain in production only
     var.site_settings.top_level_domain == "" || var.deployment != "prod" ? [] : [var.site_settings.top_level_domain],
-    var.site_settings.additional_domains == null ? tolist([]) : (var.deployment != "prod" ? tolist([]) : tolist(var.site_settings.additional_domains)),
+    var.site_settings.additional_domains == null ? tolist([]) : tolist(var.site_settings.additional_domains),
     # This is for the optional global accelerator
     try(var.site_settings.global_accelerator, "") == "" ? [] : flatten([var.site_settings.global_accelerator]),
     try(var.site_settings.additional_certs, var.additional_certs)

--- a/certs.tf
+++ b/certs.tf
@@ -1,5 +1,5 @@
 locals {
-  
+
   #domain = "${var.deployment}.${var.site_settings.route53_domain}"
   domain = "${var.site_settings.top_level_domain}.${var.deployment}.${var.route53_tld}"
   sans = distinct(concat(
@@ -45,7 +45,7 @@ resource "aws_route53_record" "site_val_record" {
   zone_id         = data.aws_route53_zone.subdomain.zone_id
 }
 
-resource "infoblox_cname_record" "aws_cert_cname_record_tamu"{
+resource "infoblox_cname_record" "aws_cert_cname_record_tamu" {
   for_each = {
     for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
@@ -55,28 +55,28 @@ resource "infoblox_cname_record" "aws_cert_cname_record_tamu"{
     } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && local.use_infoblox
   }
 
-  canonical	= trim(each.value.record, ".")
-  alias 		= trim(each.value.name, ".")
-  ttl 			= 3600
-	dns_view	= "TAMU"
-  comment 	= "Certificate validation record for AWS static site ${var.site_settings.top_level_domain}"
+  canonical = trim(each.value.record, ".")
+  alias     = trim(each.value.name, ".")
+  ttl       = 3600
+  dns_view  = "TAMU"
+  comment   = "Certificate validation record for AWS static site ${var.site_settings.top_level_domain}"
 }
 
-resource "infoblox_cname_record" "aws_cert_cname_record_internet"{
+resource "infoblox_cname_record" "aws_cert_cname_record_internet" {
   for_each = {
     for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
-    #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
+      #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
     } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && local.use_infoblox
   }
 
-  canonical	= trim(each.value.record, ".")
-  alias 		= trim(each.value.name, ".")
-  ttl 			= 3600
-	dns_view	= "Internet"
-  comment 	= "Certificate validation record for AWS static site ${var.site_settings.top_level_domain}"
+  canonical = trim(each.value.record, ".")
+  alias     = trim(each.value.name, ".")
+  ttl       = 3600
+  dns_view  = "Internet"
+  comment   = "Certificate validation record for AWS static site ${var.site_settings.top_level_domain}"
 }
 
 # Validate certs. This will fail on a non-route53 domain

--- a/certs.tf
+++ b/certs.tf
@@ -52,7 +52,7 @@ resource "infoblox_cname_record" "aws_cert_cname_record_tamu" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
       #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
-    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && !contains(var.external_validation_list, dvo.domain_name) && local.use_infoblox
+    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && !contains(var.site_settings.external_domains, dvo.domain_name) && local.use_infoblox
   }
 
   canonical = trim(each.value.record, ".")
@@ -69,7 +69,7 @@ resource "infoblox_cname_record" "aws_cert_cname_record_internet" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
       #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
-    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && local.use_infoblox
+    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && !contains(var.site_settings.external_domains, dvo.domain_name) && local.use_infoblox
   }
 
   canonical = trim(each.value.record, ".")
@@ -87,7 +87,7 @@ locals {
     name   = dvo.resource_record_name
     record = dvo.resource_record_value
     type   = dvo.resource_record_type
-    } if contains(var.external_validation_list, dvo.domain_name)
+    } if contains(var.site_settings.external_domains, dvo.domain_name)
   }
   records_output = join("\n", [for domain, dvo in local.manual_dvos : <<-EOT
     Create the following DNS Record (for ${domain}):

--- a/certs.tf
+++ b/certs.tf
@@ -53,7 +53,7 @@ resource "infoblox_cname_record" "aws_cert_cname_record_tamu" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
       #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
-    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && !contains(var.site_settings.external_domains, dvo.domain_name) && local.use_infoblox
+    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && !contains(try(var.site_settings.external_domains, []), dvo.domain_name) && local.use_infoblox
   }
 
   canonical = trim(each.value.record, ".")
@@ -70,7 +70,7 @@ resource "infoblox_cname_record" "aws_cert_cname_record_internet" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
       #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
-    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && !contains(var.site_settings.external_domains, dvo.domain_name) && local.use_infoblox
+    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && !contains(try(var.site_settings.external_domains, []), dvo.domain_name) && local.use_infoblox
   }
 
   canonical = trim(each.value.record, ".")
@@ -88,7 +88,7 @@ locals {
     name   = dvo.resource_record_name
     record = dvo.resource_record_value
     type   = dvo.resource_record_type
-    } if contains(var.site_settings.external_domains, dvo.domain_name)
+    } if contains(try(var.site_settings.external_domains, []), dvo.domain_name)
   }
   records_output = join("\n", [for domain, dvo in local.manual_dvos : <<-EOT
     Create the following DNS Record (for ${domain}):

--- a/certs.tf
+++ b/certs.tf
@@ -102,7 +102,8 @@ locals {
 
 resource "terraform_data" "external_dns_instructions" {
   # This triggers the resource to run every time the cert changes
-  input = aws_acm_certificate.cert.arn
+  input            = aws_acm_certificate.cert.arn
+  triggers_replace = aws_acm_certificate.cert.arn
 
   # Echo the values to stdout using local-exec
   provisioner "local-exec" {

--- a/certs.tf
+++ b/certs.tf
@@ -51,8 +51,8 @@ resource "infoblox_cname_record" "aws_cert_cname_record_tamu" {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
-    #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
-    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && local.use_infoblox
+      #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
+    } if endswith(dvo.domain_name, "tamu.edu") && !endswith(dvo.domain_name, ".cloud.tamu.edu") && !contains(var.external_validation_list, dvo.domain_name) && local.use_infoblox
   }
 
   canonical = trim(each.value.record, ".")

--- a/certs.tf
+++ b/certs.tf
@@ -103,7 +103,7 @@ locals {
 resource "terraform_data" "external_dns_instructions" {
   # This triggers the resource to run every time the cert changes
   input            = aws_acm_certificate.cert.arn
-  triggers_replace = aws_acm_certificate.cert.arn
+  triggers_replace = [aws_acm_certificate.cert.arn]
 
   # Echo the values to stdout using local-exec
   provisioner "local-exec" {

--- a/certs.tf
+++ b/certs.tf
@@ -6,7 +6,7 @@ locals {
     [local.domain],
     # This is for the top-level domain in production only
     var.site_settings.top_level_domain == "" || var.deployment != "prod" ? [] : [var.site_settings.top_level_domain],
-    var.site_settings.additional_domains == null ? tolist([]) : tolist(var.site_settings.additional_domains),
+    var.site_settings.additional_domains == null ? tolist([]) : (var.deployment != "prod" ? tolist([]) : tolist(var.site_settings.additional_domains)),
     var.site_settings.external_domains == null ? tolist([]) : tolist(var.site_settings.external_domains),
     # This is for the optional global accelerator
     try(var.site_settings.global_accelerator, "") == "" ? [] : flatten([var.site_settings.global_accelerator]),

--- a/certs.tf
+++ b/certs.tf
@@ -7,6 +7,7 @@ locals {
     # This is for the top-level domain in production only
     var.site_settings.top_level_domain == "" || var.deployment != "prod" ? [] : [var.site_settings.top_level_domain],
     var.site_settings.additional_domains == null ? tolist([]) : tolist(var.site_settings.additional_domains),
+    var.site_settings.external_domains == null ? tolist([]) : tolist(var.site_settings.external_domains),
     # This is for the optional global accelerator
     try(var.site_settings.global_accelerator, "") == "" ? [] : flatten([var.site_settings.global_accelerator]),
     try(var.site_settings.additional_certs, var.additional_certs)

--- a/certs.tf
+++ b/certs.tf
@@ -7,7 +7,7 @@ locals {
     # This is for the top-level domain in production only
     var.site_settings.top_level_domain == "" || var.deployment != "prod" ? [] : [var.site_settings.top_level_domain],
     var.site_settings.additional_domains == null ? tolist([]) : (var.deployment != "prod" ? tolist([]) : tolist(var.site_settings.additional_domains)),
-    var.site_settings.external_domains == null ? tolist([]) : tolist(var.site_settings.external_domains),
+    try(var.site_settings.external_domains, tolist([])),
     # This is for the optional global accelerator
     try(var.site_settings.global_accelerator, "") == "" ? [] : flatten([var.site_settings.global_accelerator]),
     try(var.site_settings.additional_certs, var.additional_certs)

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -2,7 +2,7 @@ locals {
   aliases = distinct(concat(
     [local.domain],
     var.site_settings.top_level_domain == "" || var.deployment != "prod" ? [] : [var.site_settings.top_level_domain],
-    var.site_settings.additional_domains == null ? tolist([]) : tolist(var.site_settings.additional_domains),
+    var.site_settings.additional_domains == null ? tolist([]) : (var.deployment != "prod" ? tolist([]) : tolist(var.site_settings.additional_domains)),
     var.site_settings.external_domains == null ? tolist([]) : tolist(var.site_settings.external_domains),
     try(var.site_settings.additional_cloudfront_aliases, tolist([]))
   ))

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -3,7 +3,7 @@ locals {
     [local.domain],
     var.site_settings.top_level_domain == "" || var.deployment != "prod" ? [] : [var.site_settings.top_level_domain],
     var.site_settings.additional_domains == null ? tolist([]) : (var.deployment != "prod" ? tolist([]) : tolist(var.site_settings.additional_domains)),
-    var.site_settings.external_domains == null ? tolist([]) : tolist(var.site_settings.external_domains),
+    try(var.site_settings.external_domains, tolist([])),
     try(var.site_settings.additional_cloudfront_aliases, tolist([]))
   ))
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -2,7 +2,7 @@ locals {
   aliases = distinct(concat(
     [local.domain],
     var.site_settings.top_level_domain == "" || var.deployment != "prod" ? [] : [var.site_settings.top_level_domain],
-    var.site_settings.additional_domains == null ? tolist([]) : (var.deployment != "prod" ? tolist([]) : tolist(var.site_settings.additional_domains)),
+    var.site_settings.additional_domains == null ? tolist([]) : tolist(var.site_settings.additional_domains),
     try(var.site_settings.additional_cloudfront_aliases, tolist([]))
   ))
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -3,6 +3,7 @@ locals {
     [local.domain],
     var.site_settings.top_level_domain == "" || var.deployment != "prod" ? [] : [var.site_settings.top_level_domain],
     var.site_settings.additional_domains == null ? tolist([]) : tolist(var.site_settings.additional_domains),
+    var.site_settings.external_domains == null ? tolist([]) : tolist(var.site_settings.external_domains),
     try(var.site_settings.additional_cloudfront_aliases, tolist([]))
   ))
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -16,7 +16,7 @@ locals {
   #  try(var.site_settings.cors_allowed_origins, null) != null
   #)
   use_response_headers_default_policy = false
-  response_headers_policy_id = local.use_response_headers_default_policy ? data.aws_cloudfront_response_headers_policy.site_default.id : aws_cloudfront_response_headers_policy.site[0].id
+  response_headers_policy_id          = local.use_response_headers_default_policy ? data.aws_cloudfront_response_headers_policy.site_default.id : aws_cloudfront_response_headers_policy.site[0].id
 
   use_oac_default_policy = false
 }
@@ -794,7 +794,7 @@ data "aws_cloudfront_response_headers_policy" "site_default" {
 
 
 resource "aws_cloudfront_origin_access_control" "site" {
-  count = local.use_oac_default_policy ? 0 : 1
+  count                             = local.use_oac_default_policy ? 0 : 1
   name                              = substr("site-origin-access-control-${replace(var.site_settings.top_level_domain, ".", "-")}-${var.deployment}", 0, 64)
   description                       = "Site Policy (${var.site_settings.top_level_domain}-${var.deployment}))"
   origin_access_control_origin_type = "s3"

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,3 +19,14 @@ output "deployment" {
 output "top_level_domain" {
   value = var.site_settings.top_level_domain
 }
+
+output "external_validation_records" {
+  value = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+      #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
+    } if endswith(dvo.domain_name, ".cloud.tamu.edu") || contains(var.external_validation_list, dvo.domain_name)
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,6 +27,6 @@ output "external_validation_records" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
       #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
-    } if endswith(dvo.domain_name, ".cloud.tamu.edu") || contains(var.site_settings.external_domains, dvo.domain_name)
+    } if contains(try(var.site_settings.external_domains, []), dvo.domain_name)
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,6 +27,6 @@ output "external_validation_records" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
       #} if length(regexall("${var.site_settings.top_level_domain}$", dvo.domain_name)) > 0
-    } if endswith(dvo.domain_name, ".cloud.tamu.edu") || contains(var.external_validation_list, dvo.domain_name)
+    } if endswith(dvo.domain_name, ".cloud.tamu.edu") || contains(var.site_settings.external_domains, dvo.domain_name)
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,12 @@ variable "error_response_404_path" {
   default     = "/error/404.html"
 }
 
+variable "external_validation_list" {
+  type        = list(string)
+  default     = []
+  description = "A list of SANs that will need validation records created outside of this module. Note: these values must be created in the external DNS system while this module is being applied, or the validation and issuance process will time out."
+}
+
 # This was moved to lambda.tf so that localstack could use that file independently
 #variable "enable_hostname_rewrites" {
 #  type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -81,12 +81,6 @@ variable "error_response_404_path" {
   default     = "/error/404.html"
 }
 
-variable "external_validation_list" {
-  type        = list(string)
-  default     = []
-  description = "A list of SANs that will need validation records created outside of this module. Note: these values must be created in the external DNS system while this module is being applied, or the validation and issuance process will time out."
-}
-
 # This was moved to lambda.tf so that localstack could use that file independently
 #variable "enable_hostname_rewrites" {
 #  type        = bool


### PR DESCRIPTION
This pull request introduces support for alias domains that are not in an authoritative Infoblox zone as reported in #28. Since is unlikely to be the only time a non-infoblox zone is used, a new site setting has been added to specify domains requiring manual validation, ensures these domains are excluded from automatic Infoblox record creation, outputs the required records for operator visibility, and provides clear instructions for manual DNS record creation.

> [!NOTE]
>  Ideally, automatic validation support for more production TAMU DNS providers can be added later, such as for Route53, Azure DNS, and Cloudflare, to avoid manual steps.

**Support for external DNS validation records:**

* Added a new site settings key, `external_domains`, to specify domains (SANs) that require manual DNS validation outside the module.
* Updated the Infoblox CNAME record resource to exclude external domains from automatic record creation.

**Operator visibility and instructions:**

* Introduced a local value and a `terraform_data` resource to print instructions and the required DNS records for manual creation to the operator during apply, ensuring manual steps are clearly communicated.
* Added an output, `external_validation_records`, to expose the required external validation DNS records, making it easier for operators to retrieve and use this information.

The terraform output will now display the following instructions for any `external_domains` and the subsequent `aws_acm_certificate_validation` resource will attempt to validate the records for 10 minutes:

```
module.aws_static_site.terraform_data.external_dns_instructions (local-exec): ------------------------------------------------------------------------
module.aws_static_site.terraform_data.external_dns_instructions (local-exec): MANUAL DNS RECORDS REQUIRED FOR CERTIFICATE VALIDATION
module.aws_static_site.terraform_data.external_dns_instructions (local-exec): Certificate validation will not succeed until these records are created.
module.aws_static_site.terraform_data.external_dns_instructions (local-exec): ------------------------------------------------------------------------
module.aws_static_site.terraform_data.external_dns_instructions (local-exec): Create the following DNS Record (for blake-test.tamu.site):
module.aws_static_site.terraform_data.external_dns_instructions (local-exec): Type:  CNAME
module.aws_static_site.terraform_data.external_dns_instructions (local-exec): Name:  _d4fd7d6e57302521ad95341d94fa531b.blake-test.tamu.site.
module.aws_static_site.terraform_data.external_dns_instructions (local-exec): Value: _e88e93bd024aa651aa570969c0430c01.jkddzztszm.acm-validations.aws.
module.aws_static_site.terraform_data.external_dns_instructions (local-exec): ------------------------------------------------------------------------
```