### PR TITLE
Fixes order of operations for cloudfront policies to allow for upgrades

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -721,7 +721,9 @@ resource "aws_cloudfront_distribution" "site" {
   depends_on = [
     aws_acm_certificate_validation.cert,
     aws_s3_bucket_ownership_controls.bucket,
-    aws_s3_bucket_ownership_controls.bucket_logging
+    aws_s3_bucket_ownership_controls.bucket_logging,
+    (local.use_response_headers_default_policy == false ? aws_cloudfront_response_headers_policy.site : null),
+    (local.use_oac_default_policy == false ? aws_cloudfront_origin_access_control.site : null)
   ]
 }
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -722,8 +722,8 @@ resource "aws_cloudfront_distribution" "site" {
     aws_acm_certificate_validation.cert,
     aws_s3_bucket_ownership_controls.bucket,
     aws_s3_bucket_ownership_controls.bucket_logging,
-    (local.use_response_headers_default_policy == false ? aws_cloudfront_response_headers_policy.site : null),
-    (local.use_oac_default_policy == false ? aws_cloudfront_origin_access_control.site : null)
+    aws_cloudfront_response_headers_policy.site,
+    aws_cloudfront_origin_access_control.site
   ]
 }
 


### PR DESCRIPTION
This may be all that's necessary to let Terraform know to update the cloudfront distribution first before attempting to destroy any dependent resources.

This dependency was missing before, since an implicit dependency connection was interrupted by two `local` values. Another method could have been to remove the use of the local and allow the dependency connection to be detected.

All modules currently using v3.2 will need to be updated to a new 3.2.x release first before v3.3, to allow for the dependency graph to be updated and committed to state first.

One thing that's untested/unknown: is having this dependency in the statefile enough to coersce the correct behavior when the explicit dependency goes away in v3.3?